### PR TITLE
fix: use /tmp instead of /var/tmp

### DIFF
--- a/vars.py
+++ b/vars.py
@@ -10,7 +10,7 @@ import tempfile
 if system() == 'Windows':
     TEMP_PATH = tempfile.gettempdir()
 else:
-    TEMP_PATH = '/var/tmp/'
+    TEMP_PATH = '/tmp/'
 
 # For determining whether we're installing or updating/repairing the game
 INSTALLED = False


### PR DESCRIPTION
Beans should use `/tmp` instead of `/var/tmp`.

Here is a snippet of a comment describing the difference between `/tmp` and `/var/tmp`
`
/tmp is meant as fast (possibly small) storage with a short lifetime. Many systems clean /tmp very fast - on some systems it is even mounted as RAM-disk. /var/tmp is normally located on a physical disk, is larger and can hold temporary files for a longer time. Some systems also clean /var/tmp, but less often.`

Basically, `/var/tmp` is used for temporary files that need more persistence between reboots. i.e., this folder does not get cleaned on reboot. While `/tmp` is truly for temporary files and does get cleaned between reboots.

Beans, by using `/var/tmp`, has left a 3GB file in my /var/tmp eating up disk space. This, plus the fact that ones somebody uses the installer, they will be extremely unlikely to download it again, means that it should be considered to use `/tmp` instead of `/var/tmp`